### PR TITLE
Support Long device names et al

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,28 +167,42 @@ Simple and intuitive Packet Sniffing Program
 Usage: sniph [OPTIONS]
 
 Options:
-  -d, --devices                Prints devices or interfaces found on system and exits
-  -i, --interface <INTERFACE>  interface to sniff on. Will exit with an error if the interface cannot be found
-  -o, --output <OUTPUT>        Optional output folder where report will be written to. If no output is specified, no report is written output will be a folder with name report_YYYY_MM_DD_H_M_S containing a report in csv and 2 SVG files showing data and packet throughput
-  -b, --buffer <BUFFER>        size of print buffer, if set to 0, packets will be printed to stdout immediately.
-                               if set to a larger number, calls to stdout will be buffered up to this value and then written to stdout. [default: 1024]
-  -q, --quiet                  If captured packets should be printed to stdout in realtime, quiet mode can result in better performance as there won't be calls to print to console
-  -f, --filter <FILTER>        Filters to apply to captured packets E.g src_port > 8000 or dst_port < 4000
-                               Multiple filters can be combined by commas (e.g src_ip > 8000, dst_ip < 4000)
-                               Each filter should be in the format <field> <operator> <value>
-                               Supported fields: src_ip, dst_ip, src_port, dst_port, transport
-                               Supported operators: >, <, >=, <=, ==, !=
-                               Example: --filter "src_ip == 192.168.1.1"
-                               Example: --filter "src_port >= 8000, dst_port < 4000"
-                               Note: A space must exist between the field, operator and value
-                               Note: No spaces between commas and next filter
-                               If no filter is provided, all packets are captured
-                               == and != operators are string comparisons and only valid for IP addresses and protocol
-                               >, <, >=, <= operators are numeric comparisons and only valid for ports
-  -w, --window <WINDOW>        time window to group packet statistics together before writing to output file
-                               Not supplying a window means that statistics will be aggregated in memory for the entire length of the program running which can lead to increased memory consumption
-  -h, --help                   Print help
-  -V, --version                Print version
+  -d, --devices
+          Prints devices or interfaces found on system and exits
+  -i, --interface <INTERFACE>
+          interface to sniff on. Will exit with an error if the interface cannot be found
+  -o, --output <OUTPUT>
+          Optional output folder where report will be written to. If no output is specified, no report is written output will be a folder with name report_YYYY_MM_DD_H_M_S containing a report in csv and 2 SVG files showing data and packet throughput
+  -b, --buffer <BUFFER>
+          size of print buffer, if set to 0, packets will be printed to stdout immediately.
+          if set to a larger number, calls to stdout will be buffered up to this value and then written to stdout. [default: 1024]
+  -q, --quiet
+          If captured packets should be printed to stdout in realtime, quiet mode can result in better performance as there won't be calls to print to console
+  -f, --filter <FILTER>
+          Filters to apply to captured packets E.g src_port > 8000 or dst_port < 4000
+          Multiple filters can be combined by commas (e.g src_ip > 8000, dst_ip < 4000)
+          Each filter should be in the format <field> <operator> <value>
+          Supported fields: src_ip, dst_ip, src_port, dst_port, transport
+          Supported operators: >, <, >=, <=, ==, !=
+          Example: --filter "src_ip == 192.168.1.1"
+          Example: --filter "src_port >= 8000, dst_port < 4000"
+          Note: A space must exist between the field, operator and value
+          Note: No spaces between commas and next filter
+          If no filter is provided, all packets are captured
+          == and != operators are string comparisons and only valid for IP addresses and protocol
+          >, <, >=, <= operators are numeric comparisons and only valid for ports
+  -w, --window <WINDOW>
+          time window to group packet statistics together before writing to output file
+          Not supplying a window means that statistics will be aggregated in memory for the entire length of the program running which can lead to increased memory consumption
+      --max-packet-size <MAX_PACKET_SIZE>
+          Optional packet size limit for captured packets
+          Setting to a lower value can result in better performance as less data is copied from kernel space to user space
+          However, setting to a lower value means that some packets may be truncated and therefore dropped by the packet parser
+          Default is 5000 bytes which should be sufficient for most use cases [default: 5000]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ fn read_user_input(signaller: Arc<Signaller>) {
     IP::UNCACHED("".to_string());
 }
 fn print_devices() {
-    const DEVICE_COLUMN_WIDTH: usize = 20;
+    let mut DEVICE_COLUMN_WIDTH: usize = 20;
     const ADDRESS_COLUMN_WIDTH: usize = 50;
 
     let devices = pcap::Device::list().unwrap_or_else(|e| {
@@ -208,6 +208,14 @@ fn print_devices() {
     let mut writer = BufWriter::new(std::io::stdout());
     let hyphen_line = format!("{}{}{}", "+", "-".repeat(74_usize), "+");
 
+    let max_device_name_length = devices
+        .iter()
+        .map(|d| d.name.len())
+        .max()
+        .unwrap_or(DEVICE_COLUMN_WIDTH);
+    
+
+    DEVICE_COLUMN_WIDTH = DEVICE_COLUMN_WIDTH.max(max_device_name_length + 2); // add some padding
     writer
         .write_all(format!("{}\n", hyphen_line).as_bytes())
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,14 @@ struct Args {
     /// Not supplying a window means that statistics will be aggregated in memory for the entire length of the program running which can lead to increased memory consumption
     #[arg(short, long, verbatim_doc_comment)]
     window: Option<u32>,
+
+    /// Optional packet size limit for captured packets
+    /// Setting to a lower value can result in better performance as less data is copied from kernel space to user space
+    /// However, setting to a lower value means that some packets may be truncated and therefore dropped by the packet parser
+    /// Default is 5000 bytes which should be sufficient for most use cases
+    #[arg(long, default_value = "5000", verbatim_doc_comment)]
+    max_packet_size: u16,
+
 }
 
 fn main() {
@@ -120,7 +128,7 @@ fn main() {
     let input_signal = Arc::clone(&signaller);
 
     enable_raw_mode().unwrap();
-    let sniffer_handle = match Sniffer::new(interface, args.quiet, args.buffer) {
+    let sniffer_handle = match Sniffer::new(interface, args.quiet, args.buffer, args.max_packet_size) {
         Ok(sniffer) => std::thread::spawn(move || {
             sniffer.start(packet_parser_signal, sniffer_packet_info, packet_filter)
         }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,16 +206,20 @@ fn print_devices() {
     });
 
     let mut writer = BufWriter::new(std::io::stdout());
-    let hyphen_line = format!("{}{}{}", "+", "-".repeat(74_usize), "+");
+    
 
     let max_device_name_length = devices
         .iter()
-        .map(|d| d.name.len())
+        .map(|d| d.name.len() + 2)
         .max()
         .unwrap_or(DEVICE_COLUMN_WIDTH);
+
+
     
 
-    DEVICE_COLUMN_WIDTH = DEVICE_COLUMN_WIDTH.max(max_device_name_length + 2); // add some padding
+    DEVICE_COLUMN_WIDTH = DEVICE_COLUMN_WIDTH.max(max_device_name_length); // add some padding
+
+    let hyphen_line = format!("{}{}{}", "+", "-".repeat(DEVICE_COLUMN_WIDTH + 54), "+");
     writer
         .write_all(format!("{}\n", hyphen_line).as_bytes())
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,16 +206,12 @@ fn print_devices() {
     });
 
     let mut writer = BufWriter::new(std::io::stdout());
-    
 
     let max_device_name_length = devices
         .iter()
         .map(|d| d.name.len() + 2)
         .max()
         .unwrap_or(DEVICE_COLUMN_WIDTH);
-
-
-    
 
     DEVICE_COLUMN_WIDTH = DEVICE_COLUMN_WIDTH.max(max_device_name_length); // add some padding
 

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -106,6 +106,7 @@ impl Sniffer {
         let mut received_bytes: u128 = 0;
         let mut packets_sent: u128 = 0;
         let mut packets_received: u128 = 0;
+        let mut dropped_packets: u128 = 0;
         let mut current_time_window: Arc<DateTime<Local>> = Arc::new(Local::now());
 
         let addresses = self
@@ -172,7 +173,7 @@ impl Sniffer {
                             .unwrap()
                             .promisc(true)
                             .timeout(1000)
-                            .snaplen(4000) // we only need the header, we don't need the body
+                            .snaplen(5000)
                             .immediate_mode(true)
                             .open()
                             .unwrap();
@@ -195,14 +196,15 @@ impl Sniffer {
                     }
                     writeln!(
                         writer,
-                        "\r\n\r\nCaptured Packets: {}\r\nSkipped Packets: {}\r\nBytes Transferred: {}\r\nBytes Received: {}\r\nPackets Sent: {}\r\nPackets Received: {}\r\nFiltered Packets: {}\r",
+                        "\r\n\r\nCaptured Packets: {}\r\nSkipped Packets: {}\r\nBytes Transferred: {}\r\nBytes Received: {}\r\nPackets Sent: {}\r\nPackets Received: {}\r\nFiltered Packets: {}\r\nDropped Packets: {}\r",
                         captured_packets,
                         skipped_packets,
                         format_number_to_units(transferred_bytes) + "B",
                         format_number_to_units(received_bytes) + "B",
                         packets_sent,
                         packets_received,
-                        filtered_packets
+                        filtered_packets,
+                        dropped_packets
                     );
                     drop(signal);
                     break;
@@ -223,7 +225,15 @@ impl Sniffer {
                     let mut packet_size: u128 = packet.header.len as u128;
                     let mut skip = false;
                     let mut traffic_direction = TrafficDirection::OTHER;
-                    let headers = PacketHeaders::from_ethernet_slice(&packet.data).unwrap();
+
+                    let headers = match PacketHeaders::from_ethernet_slice(&packet.data) {
+                        Ok(headers) => headers,
+                        Err(_) => {
+                            // this mostly happens when we capture a packet whose size is greater than our snaplen, we can drop for now until we find a better solution that won't consume too much memory
+                            dropped_packets += 1;
+                            continue;
+                        }
+                    };
                     match headers.net {
                         None => continue,
                         Some(netHeaders) => {

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -24,10 +24,11 @@ pub struct Sniffer {
     device: Device,
     quiet: bool,
     stdout_buffer_size: usize,
+    max_packet_size: u16,
 }
 
 impl Sniffer {
-    pub fn new(interface: String, quiet: bool, buffer_size: u16) -> Result<Sniffer, String> {
+    pub fn new(interface: String, quiet: bool, buffer_size: u16, max_packet_size: u16) -> Result<Sniffer, String> {
         let mut adapter_as_device: Option<Device> = None;
         let devices = Device::list().expect("Could not list devices");
         for device in devices {
@@ -44,6 +45,7 @@ impl Sniffer {
                 device: adapter_as_device.unwrap(),
                 quiet,
                 stdout_buffer_size: buffer_size as usize,
+                max_packet_size,
             })
         }
     }
@@ -155,7 +157,7 @@ impl Sniffer {
             .unwrap()
             .promisc(true)
             .timeout(1000)
-            .snaplen(4000) // we only need the header, we don't need the body
+            .snaplen(self.max_packet_size as i32) 
             .immediate_mode(true)
             .open()
             .unwrap();


### PR DESCRIPTION
- Support Long device names
- Add flag for max packet length to parse and dropped packets that are larger than the specified packet length